### PR TITLE
Merge no-gzip-on-build to master branch

### DIFF
--- a/src/tarball.rs
+++ b/src/tarball.rs
@@ -14,7 +14,7 @@ pub fn dir<W>(
 where
     W: Write,
 {
-    let mut archive = Builder::new(GzEncoder::new(buf, Compression::best()));
+    let mut archive = Builder::new(buf);
     fn bundle<F>(
         dir: &Path,
         f: &mut F,


### PR DESCRIPTION
Use a buffer object instead of making a tarball of the docker image. This speeds up the image builder task.