### PR TITLE
Add build option skip_gzip

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -121,7 +121,7 @@ impl<'docker> Images<'docker> {
         // stream. But for backwards compatability, we have to return the error inside of the
         // stream.
         let mut bytes = Vec::default();
-        let tar_result = tarball::dir(&mut bytes, opts.path.as_str());
+        let tar_result = tarball::dir(&mut bytes, opts.path.as_str(), opts.skip_gzip);
 
         // We must take ownership of the Docker reference. If we don't then the lifetime of 'stream
         // is incorrectly tied to `self`.
@@ -557,6 +557,10 @@ impl PullOptionsBuilder {
 pub struct BuildOptions {
     pub path: String,
     params: HashMap<&'static str, String>,
+    // Custom parameter to avoid creating a tar object of the docker
+    // image when you do an image build. Instead work with a normal
+    // archive buffer.
+    skip_gzip: bool,
 }
 
 impl BuildOptions {
@@ -588,6 +592,7 @@ impl BuildOptions {
 pub struct BuildOptionsBuilder {
     path: String,
     params: HashMap<&'static str, String>,
+    skip_gzip: bool,
 }
 
 impl BuildOptionsBuilder {
@@ -691,6 +696,14 @@ impl BuildOptionsBuilder {
         self
     }
 
+    pub fn set_skip_gzip(
+        &mut self,
+        skip_gzip: bool,
+    ) -> &mut Self {
+        self.skip_gzip = skip_gzip;
+        self
+    }
+
     // todo: memswap
     // todo: cpusetcpus
     // todo: cpuperiod
@@ -701,6 +714,7 @@ impl BuildOptionsBuilder {
         BuildOptions {
             path: self.path.clone(),
             params: self.params.clone(),
+            skip_gzip: self.skip_gzip,
         }
     }
 }

--- a/src/tarball.rs
+++ b/src/tarball.rs
@@ -14,7 +14,17 @@ pub fn dir<W>(
 where
     W: Write,
 {
-    let mut archive = Builder::new(GzEncoder::new(buf, Compression::best()));
+    let skip_gzip = true;
+    let mut buf_archive;
+    let mut gzip_archive;
+    let archive: &mut Box<dyn Write> = if skip_gzip == true {
+        buf_archive = Builder::new(buf);
+        &mut buf_archive
+    } else {
+        gzip_archive = Builder::new(GzEncoder::new(buf, Compression::best()));
+        &mut gzip_archive
+    };
+    //let mut archive = Builder::new(buf);
     fn bundle<F>(
         dir: &Path,
         f: &mut F,
@@ -38,7 +48,6 @@ where
         }
         Ok(())
     }
-
     {
         let base_path = Path::new(path).canonicalize()?;
         // todo: don't unwrap


### PR DESCRIPTION
Allow user to pass a build option skip_gzip during image build process to check if the builder should create a tar object from the image or use an archive buffer only. SALM-269.