### PR TITLE
Add accessor returning image size during download

### DIFF
--- a/examples/imagepull.rs
+++ b/examples/imagepull.rs
@@ -14,11 +14,20 @@ async fn main() {
 
     let mut stream = docker
         .images()
-        .pull(&PullOptions::builder().image(img).build());
+        .pull(&PullOptions::builder().image(&img).build());
 
+    let mut print_image_size = true;
     while let Some(pull_result) = stream.next().await {
         match pull_result {
-            Ok(output) => println!("{:?}", output),
+            Ok(output) => {
+                println!("{:?}", output);
+                if print_image_size {
+                    if let Some(image_size) = output.total_image_bytes() {
+                        println!("{} image total download bytes: {}", img, image_size);
+                        print_image_size = false;
+                    }
+                }
+            }
             Err(e) => eprintln!("Error: {}", e),
         }
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -13,9 +13,9 @@ use crate::{docker::Docker, errors::Result, tarball, transport::tar};
 
 #[cfg(feature = "chrono")]
 use crate::datetime::datetime_from_unix_timestamp;
+use crate::Error;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, Utc};
-use crate::Error;
 
 /// Interface for accessing and manipulating a named docker image
 ///
@@ -981,6 +981,26 @@ pub enum ImageBuildChunk {
         #[serde(rename = "progressDetail")]
         progress_detail: Option<ProgressDetail>,
     },
+}
+
+impl ImageBuildChunk {
+    /// Return the total image size during download (if available).
+    pub fn total_image_bytes(&self) -> Option<u64> {
+        match self {
+            ImageBuildChunk::PullStatus {
+                status: _,
+                id: _,
+                progress: _,
+                progress_detail,
+            } => {
+                if let Some(detail) = progress_detail {
+                    return detail.total;
+                }
+            }
+            _ => (),
+        }
+        None
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
## What did you implement:

`fn ImageBuildChunk::total_image_bytes()` allows one to discover the eventual (compressed) image size early in the download sequence, before the whole image is retrieved.

Closes: #4

## How did you verify your change:

Added code to `examples/imagepull.rs` that exercises the new function.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

I looked at adding something to the CHANGELOG, but am confused by the format: the top section is for version 0.8.0, which doesn't exist yet, and the last change to it was 1.5 years ago, so it can't be current.

Anyway, the verbiage would be the sentence under "What did you implement."

## Misc.

I used the stipulated `cargo fmt` command, which produced several changes outside of the code that I touched. I'm only submitting the changes relevant to this new feature.