### PR TITLE
Add accessor returning layer ID and size

### DIFF
--- a/examples/imagepull_layers.rs
+++ b/examples/imagepull_layers.rs
@@ -1,0 +1,61 @@
+// cargo run --example imagepull_layers sagemathinc/cocalc
+//
+// Pull an image, keeping note of the total compressed size as the layer
+// information comes in.
+
+use futures::StreamExt;
+use shiplift::{Docker, PullOptions};
+use std::{
+    collections::HashMap,
+    env,
+    io::{self, Write},
+};
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let docker = Docker::new();
+    let img = env::args()
+        .nth(1)
+        .expect("You need to specify an image name");
+
+    let mut stream = docker
+        .images()
+        .pull(&PullOptions::builder().image(&img).build());
+
+    let mut layers = HashMap::new();
+    let mut layer_count: u32 = 0;
+    let mut total_bytes: u64 = 0;
+    while let Some(pull_result) = stream.next().await {
+        match pull_result {
+            Ok(output) => {
+                print!(".");
+                //println!("{:?}", output);
+                if let Some((layer_id, layer_bytes)) = output.image_layer_bytes() {
+                    // We have layer information.
+                    match layers.get(&layer_id) {
+                        Some(&_bytes) => (),
+                        None => {
+                            // This is a new layer.
+                            layer_count += 1;
+                            total_bytes += layer_bytes;
+                            layers.insert(layer_id.clone(), layer_bytes);
+                            println!("\n{} image layer {} ({}) compressed bytes: {} ({:.3} MB total so far)",
+                                        img, layer_count, &layer_id, layer_bytes, total_bytes as f64 / (1024.0 * 1024.0));
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                println!("Image pull error: {:?}", e);
+                break;
+            }
+        }
+        io::stdout().flush().unwrap();
+    }
+    println!(
+        "\n{} layers totalling {:.3} MB",
+        layer_count,
+        total_bytes as f64 / (1024.0 * 1024.0)
+    );
+}

--- a/src/image.rs
+++ b/src/image.rs
@@ -984,7 +984,8 @@ pub enum ImageBuildChunk {
 }
 
 impl ImageBuildChunk {
-    /// Return the total image size during download (if available).
+    /// Return the eventual compressed image layer size during download (if
+    /// available).
     pub fn total_image_bytes(&self) -> Option<u64> {
         match self {
             ImageBuildChunk::PullStatus {
@@ -1000,6 +1001,29 @@ impl ImageBuildChunk {
             _ => (),
         }
         None
+    }
+
+    /// Returns the image layer ID and size during download.
+    ///
+    /// If both the layer ID and eventual (compressed) layer size are available
+    /// from the ImageBuildChunk, they will be returned as `Some((layer_id,
+    /// layer_size))`. Otherwise, `None` is returned.
+    pub fn image_layer_bytes(&self) -> Option<(String, u64)> {
+        match self {
+            ImageBuildChunk::PullStatus {
+                status: _,
+                id: Some(id),
+                progress: _,
+                progress_detail:
+                    Some(ProgressDetail {
+                        current: _,
+                        total: Some(total),
+                    }),
+            } => {
+                Some((id.to_string(), *total))
+            }
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
## The Issue

Applications in constrained environments should know ahead of time when an image download will be too large to process.

## The Remedy

When an image is pulled down from the repository, as each layer begins to be retrieved, the `ImageBuildChunk` object contains the layer's eventual compressed size.  This PR implements a new `ImageBuildChunk::image_layer_bytes()` function that can retrieve the corresponding layer ID and size for each chunk in which it is available.

Closes: #6

## Past Attempts

`image_layer_bytes()` solves a deficiency in my previous `ImageBuildChunk::total_image_bytes()`, which doesn't allow the layer ID's to be tracked, thus making its return value often useless as chunks for several layers may come in interleaved.  That function should probably be deprecated.

## How did you verify your change:

The `examples/imagepull_layers.rs` file was used for testing against images of various sizes and layer counts.
