### PR TITLE
Stream Docker build context when building images

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -106,7 +106,7 @@ impl<'docker> Images<'docker> {
         Images { docker }
     }
 
-    /// Builds a new image build by reading a Dockerfile in a target directory
+    /// Builds a new image by reading a Dockerfile in a target directory
     ///
     /// [Api Reference](https://docs.docker.com/engine/api/v1.41/#operation/ImageBuild)
     pub fn build(
@@ -144,6 +144,11 @@ impl<'docker> Images<'docker> {
         )
     }
 
+    /// Builds a new image by reading a build context
+    /// # Arguments
+    /// opts - options for [Api Reference](https://docs.docker.com/engine/api/v1.41/#operation/ImageBuild)
+    /// build_context - an iterator over bytes of build context archive. Format of the build context
+    /// should be equivalent to that of the original `ImageBuild` function in [Api Reference].
     pub fn build_from_raw_parts<T>(
         &self,
         opts: &BuildParams,
@@ -739,6 +744,7 @@ impl BuildOptionsBuilder {
     }
 }
 
+/// Describes arguments for [Api Reference](https://docs.docker.com/engine/api/v1.41/#operation/ImageBuild)
 #[derive(Default)]
 pub struct BuildParams {
     params: HashMap<&'static str, String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub mod network;
 pub mod service;
 pub mod volume;
 
-mod tarball;
+pub mod tarball;
 
 #[cfg(feature = "chrono")]
 mod datetime;


### PR DESCRIPTION
## What did you implement:
Adds a new variant of `build` function that accepts an iterator over the raw bytes of a Docker build context. The purposes of this change is to decrease the memory required to form an `http` request to a docker `build` function (https://docs.docker.com/engine/api/v1.42/#tag/Image/operation/ImageBuild). New `build_from_raw_parts` function processes build context by chunks produced by the iterator, it then forms a streaming `http` request to the docker build function.
While this new process is slightly slower for smaller images it uses considerably less memory for big inputs, as it doesn't load whole build context into memory to form an `http` request.
