### PR TITLE
Extend image deletion functionality

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -60,9 +60,10 @@ impl<'docker> Image<'docker> {
     }
 
     /// Deletes an image
-    ///
+    /// # Arguments
+    /// delete_options - delete operation options as described in API reference
     /// [Api Reference](https://docs.docker.com/engine/api/v1.41/#operation/ImagePrune)
-    pub async fn delete(&self, delete_options: &DeleteOptions) -> Result<Vec<Status>> {
+    pub async fn delete_with_options(&self, delete_options: &DeleteOptions) -> Result<Vec<Status>> {
         let mut path = vec![format!("/images/{}", self.name)];
 
         if let Some(query) = delete_options.serialize() {
@@ -71,6 +72,15 @@ impl<'docker> Image<'docker> {
 
         self.docker
             .delete_json::<Vec<Status>>(&path.join("?"))
+            .await
+    }
+
+    /// Deletes an image
+    ///
+    /// [Api Reference](https://docs.docker.com/engine/api/v1.41/#operation/ImagePrune)
+    pub async fn delete(&self) -> Result<Vec<Status>> {
+        self.docker
+            .delete_json::<Vec<Status>>(&format!("/images/{}", self.name)[..])
             .await
     }
 
@@ -1215,16 +1225,8 @@ pub struct DeleteOptions {
 }
 
 impl DeleteOptions {
-    /// Remove the image even if it is being used by stopped containers or has other tags
-    pub fn force(mut self) -> Self {
-        self.params.insert("force", true.to_string());
-        self
-    }
-
-    /// Do not delete untagged parent images
-    pub fn no_prune(mut self) -> Self {
-        self.params.insert("noprune", true.to_string());
-        self
+    pub fn builder() -> DeleteOptionsBuilder {
+        DeleteOptionsBuilder::default()
     }
 
     /// serialize options as a string. returns None if no options are defined
@@ -1241,48 +1243,101 @@ impl DeleteOptions {
     }
 }
 
+#[derive(Default)]
+pub struct DeleteOptionsBuilder {
+    params: HashMap<&'static str, String>,
+}
+
+impl DeleteOptionsBuilder {
+
+    /// Remove the image even if it is being used by stopped containers or has other tags
+    pub fn force(mut self) -> Self {
+        self.params.insert("force", true.to_string());
+        self
+    }
+
+    /// Do not delete untagged parent images
+    pub fn noprune(mut self) -> Self {
+        self.params.insert("noprune", true.to_string());
+        self
+    }
+
+    pub fn build(&mut self) -> DeleteOptions {
+        DeleteOptions {
+            params: self.params.clone(),
+        }
+    }
+}
+
 /// Describes query parameters for POST /images/prune
 /// https://docs.docker.com/engine/api/v1.42/#tag/Image/operation/ImagePrune
 #[derive(Default, Debug)]
 pub struct PruneOptions {
 
-    params: HashMap<&'static str, Vec<String>>,
+    filters: HashMap<&'static str, Vec<String>>,
 }
 
 impl PruneOptions {
 
-    /// dangling=<boolean> When set to true (or 1), prune only unused and untagged images.
-    /// When set to false (or 0), all unused images are pruned.
-    pub fn set_dangling(mut self, dangling: bool) -> Self {
-        self.params.insert("dangling", vec![dangling.to_string()]);
-        self
-    }
-
-    /// until=<string> Prune images created before this timestamp.
-    /// The <timestamp> can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. 10m, 1h30m) computed relative to the daemon machine’s time.
-    pub fn set_until(mut self, until: String) -> Self {
-        self.params.insert("until", vec![until]);
-        self
-    }
-
-    /// label (label=<key>, label=<key>=<value>, label!=<key>, or label!=<key>=<value>) Prune images with (or without, in case label!=... is used) the specified labels.
-    pub fn set_label(mut self, label: String) -> Self {
-        self.params.insert("label", vec![label]);
-        self
-    }
-
     /// serialize options as a string. returns None if no options are defined
     pub fn serialize(&self) -> Result<Option<String>> {
-        if self.params.is_empty() {
+        if self.filters.is_empty() {
             Ok(None)
         } else {
-            let value = serde_json::to_string(&self.params).map_err(Error::from)?;
+            let value = serde_json::to_string(&self.filters).map_err(Error::from)?;
 
             Ok(Some(
                 form_urlencoded::Serializer::new(String::new())
                     .append_pair("filters", &value)
                     .finish(),
             ))
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct PruneOptionsBuilder {
+    filters: HashMap<&'static str, Vec<String>>,
+}
+
+impl PruneOptionsBuilder {
+
+    /// dangling=<boolean> When set to true (or 1), prune only unused and untagged images.
+    /// When set to false (or 0), all unused images are pruned.
+    pub fn dangling(mut self, dangling: bool) -> Self {
+        self.filters.insert("dangling", vec![dangling.to_string()]);
+        self
+    }
+
+    /// until=<string> Prune images created before this timestamp.
+    /// The <timestamp> can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. 10m, 1h30m) computed relative to the daemon machine’s time.
+    pub fn until(mut self, until: String) -> Self {
+        self.filters.insert("until", vec![until]);
+        self
+    }
+
+    /// label (label=<key>, label=<key>=<value>, label!=<key>, or label!=<key>=<value>) Prune images with (or without, in case label!=... is used) the specified labels.
+    pub fn add_label(mut self, label: String) -> Self {
+        if let Some(label_list) = self.filters.get_mut("label") {
+            label_list.push(label)
+        } else {
+            self.filters.insert("label", vec![label]);
+        }
+
+        self
+    }
+
+    pub fn add_labels<T>(mut self, labels: T) -> Self where T: Into<Vec<String>> {
+        for label in labels.into() {
+            self = self.add_label(label)
+        }
+
+        self
+    }
+
+    pub fn build(&mut self) -> PruneOptions {
+        PruneOptions {
+            filters: self.filters.clone(),
         }
     }
 }


### PR DESCRIPTION
## What did you implement:
Extends image deletion functionality with the following:
- Adds missing parameters to **DELETE images/{name}** (https://docs.docker.com/engine/api/v1.42/#tag/Image/operation/ImageDelete)
- Adds **POST images/prune** function with it's respective arguments (https://docs.docker.com/engine/api/v1.42/#tag/Image/operation/ImagePrune)