### PR TITLE
Make virtual_size an optional field 

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -1052,7 +1052,7 @@ pub struct ImageInfo {
     pub labels: Option<HashMap<String, String>>,
     pub repo_tags: Option<Vec<String>>,
     pub repo_digests: Option<Vec<String>>,
-    pub virtual_size: u64,
+    pub virtual_size: Option<u64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1073,7 +1073,7 @@ pub struct ImageDetails {
     pub repo_tags: Option<Vec<String>>,
     pub repo_digests: Option<Vec<String>>,
     pub size: u64,
-    pub virtual_size: u64,
+    pub virtual_size: Option<u64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
According to the docker 24.0 release notes (https://docs.docker.com/engine/release-notes/24.0/) the virtual_size parameter is deprecated. 

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Updated ImageInfo and ImageDetails structures to have optional virtual_size field.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

## How did you verify your change:

Change was tested by rebuilding the salmiac converter and ensuring the below error was not produced at conversion time:
```
Encountered error when searching for local image parent-base. SerdeJsonError(Error("missing field `VirtualSize`", line: 1, column: 2749)).
```

## What (if anything) would need to be called out in the CHANGELOG for the next release: