### PR TITLE
[RTE-662] Update crate based on Docker Engine v1.52 API changes

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -1292,7 +1292,7 @@ pub struct HostConfig {
     pub device_cgroup_rules: Option<String>,
     pub device_requests: Option<Vec<DeviceRequest>>,
     #[serde(rename = "KernelMemoryTCP")]
-    pub kernel_memory_tcp: i64,
+    pub kernel_memory_tcp: Option<i64>,
     pub memory_reservation: Option<i64>,
     pub memory_swap: Option<i64>,
     pub memory_swappiness: Option<i64>,

--- a/src/image.rs
+++ b/src/image.rs
@@ -1063,17 +1063,17 @@ pub struct ImageInfo {
 #[serde(rename_all = "PascalCase")]
 pub struct ImageDetails {
     pub architecture: String,
-    pub author: String,
-    pub comment: String,
+    pub author: Option<String>,
+    pub comment: Option<String>,
     pub config: ContainerConfig,
     #[cfg(feature = "chrono")]
     pub created: DateTime<Utc>,
     #[cfg(not(feature = "chrono"))]
     pub created: String,
-    pub docker_version: String,
+    pub docker_version: Option<String>,
     pub id: String,
     pub os: String,
-    pub parent: String,
+    pub parent: Option<String>,
     pub repo_tags: Option<Vec<String>>,
     pub repo_digests: Option<Vec<String>>,
     pub size: u64,
@@ -1098,8 +1098,8 @@ pub struct ContainerConfig {
     pub open_stdin: Option<bool>,
     pub stdin_once: Option<bool>,
     pub tty: Option<bool>,
-    pub user: String,
-    pub working_dir: String,
+    pub user: Option<String>,
+    pub working_dir: Option<String>,
 }
 
 impl ContainerConfig {

--- a/src/network.rs
+++ b/src/network.rs
@@ -319,13 +319,13 @@ type PortDescription = HashMap<String, Option<Vec<HashMap<String, String>>>>;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct NetworkSettings {
-    pub bridge: String,
-    pub gateway: String,
+    pub bridge: Option<String>,
+    pub gateway: Option<String>,
     #[serde(rename = "IPAddress")]
-    pub ip_address: String,
+    pub ip_address: Option<String>,
     #[serde(rename = "IPPrefixLen")]
-    pub ip_prefix_len: u64,
-    pub mac_address: String,
+    pub ip_prefix_len: Option<u64>,
+    pub mac_address: Option<String>,
     pub ports: Option<PortDescription>,
     pub networks: HashMap<String, NetworkEntry>,
 }


### PR DESCRIPTION
Update models in `image`, `network` and `container` modules of the crate based on the changes in Docker Engine API v1.52. Multiple fields are not deprecated or removed, they are marked as optional fields now.

Reference - https://docs.docker.com/reference/api/engine/version-history/#v152-api-changes